### PR TITLE
Additional /me tests

### DIFF
--- a/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
@@ -31,9 +31,8 @@ import static org.hamcrest.Matchers.*
 class MeIT extends AbstractIT {
     private TestAccount account = new TestAccount()
     private String accessToken
-
     @BeforeClass
-    private void getTestAccountAccessToken() throws Exception {
+    private void createSession() throws Exception {
         account.registerOnServer()
 
         accessToken =
@@ -72,6 +71,22 @@ class MeIT extends AbstractIT {
      * @throws Exception
      */
     @Test
+    public void testThatMeWithCookieAuthReturnsJsonUser() throws Exception {
+        given()
+            .cookie("access_token", accessToken)
+        .when()
+            .get(FrameworkConstants.MeRoute)
+        .then()
+            .spec(AccountResponseSpec.matchesAccount(account))
+    }
+
+    /**
+     * We should be returning a user, and it should always be JSON.
+     * @see https://github.com/stormpath/stormpath-framework-tck/issues/61
+     * @see https://github.com/stormpath/stormpath-framework-tck/issues/63
+     * @throws Exception
+     */
+    @Test
     public void testThatMeWithBearerAuthReturnsJsonUser() throws Exception {
         given()
             .auth().oauth2(accessToken)
@@ -87,6 +102,21 @@ class MeIT extends AbstractIT {
      * @throws Exception
      */
     @Test
+    public void testThatMeWithCookieAuthStripsLinkedResources() throws Exception {
+        given()
+            .cookie("access_token", accessToken)
+        .when()
+            .get(FrameworkConstants.MeRoute)
+        .then()
+            .spec(AccountResponseSpec.withoutLinkedResources())
+    }
+
+    /**
+     * We should not have linked resources.
+     * @see https://github.com/stormpath/stormpath-framework-tck/issues/64
+     * @throws Exception
+     */
+    @Test
     public void testThatMeWithBearerAuthStripsLinkedResources() throws Exception {
         given()
             .auth().oauth2(accessToken)
@@ -94,6 +124,24 @@ class MeIT extends AbstractIT {
             .get(FrameworkConstants.MeRoute)
         .then()
             .spec(AccountResponseSpec.withoutLinkedResources())
+    }
+
+    /**
+     * We should not set cache headers.
+     * @see https://github.com/stormpath/stormpath-framework-tck/issues/65
+     * @throws Exception
+     */
+    @Test
+    public void testThatMeWithCookieAuthHasNoCacheHeaders() throws Exception {
+        given()
+            .cookie("access_token", accessToken)
+        .when()
+            .get(FrameworkConstants.MeRoute)
+        .then()
+            .spec(AccountResponseSpec.matchesAccount(account))
+            .header("Cache-Control", containsString("no-cache"))
+            .header("Cache-Control", containsString("no-store"))
+            .header("Pragma", is("no-cache"))
     }
 
     /**

--- a/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
@@ -31,8 +31,9 @@ import static org.hamcrest.Matchers.*
 class MeIT extends AbstractIT {
     private TestAccount account = new TestAccount()
     private String accessToken
+
     @BeforeClass
-    private void createSession() throws Exception {
+    private void getTestAccountAccessToken() throws Exception {
         account.registerOnServer()
 
         accessToken =
@@ -48,7 +49,6 @@ class MeIT extends AbstractIT {
                 .body("access_token", not(isEmptyOrNullString()))
             .extract()
                 .path("access_token")
-
         deleteOnClassTeardown(account.href)
     }
 

--- a/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
@@ -34,6 +34,8 @@ class MeIT extends AbstractIT {
 
     @BeforeClass
     private void getTestAccountAccessToken() throws Exception {
+        account.registerOnServer()
+
         accessToken =
             given()
                 .param("grant_type", "password")
@@ -47,7 +49,20 @@ class MeIT extends AbstractIT {
                 .body("access_token", not(isEmptyOrNullString()))
             .extract()
                 .path("access_token")
+
         deleteOnClassTeardown(account.href)
+    }
+
+    /** Respond with 401 if no user is authorized
+     * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/62">#62</a>
+     * @throws Exception
+     */
+    @Test
+    public void unauthorizedRequestFails() throws Exception {
+        when()
+            .get(FrameworkConstants.MeRoute)
+        .then()
+            .statusCode(401)
     }
 
     /**

--- a/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
@@ -72,7 +72,7 @@ class MeIT extends AbstractIT {
      * @throws Exception
      */
     @Test
-    public void testThatMeReturnsJsonUser() throws Exception {
+    public void testThatMeWithBearerAuthReturnsJsonUser() throws Exception {
         given()
             .auth().oauth2(accessToken)
         .when()
@@ -87,7 +87,7 @@ class MeIT extends AbstractIT {
      * @throws Exception
      */
     @Test
-    public void testThatMeStripsLinkedResources() throws Exception {
+    public void testThatMeWithBearerAuthStripsLinkedResources() throws Exception {
         given()
             .auth().oauth2(accessToken)
         .when()
@@ -102,7 +102,7 @@ class MeIT extends AbstractIT {
      * @throws Exception
      */
     @Test
-    public void testThatMeHasNoCacheHeaders() throws Exception {
+    public void testThatMeWithBearerAuthHasNoCacheHeaders() throws Exception {
         given()
             .auth().oauth2(accessToken)
         .when()


### PR DESCRIPTION
Fixes #62

@edjiang I added more tests that assert the same behavior but for cookie auth instead of bearer auth.
