### PR TITLE
Adding test suites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.12.4</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>${project.basedir}/src/test/suite-${suite}.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <properties>
+                        <property>
+                            <name>testnames</name>
+                            <value>${tag}</value>
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/test/groovy/com/stormpath/tck/authentication/CookieIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/authentication/CookieIT.groovy
@@ -58,7 +58,7 @@ class CookieIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/34">#34</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void serverRefreshesAccessTokenWhenMissing() throws Exception {
         def (String accessToken, String refreshToken) = createTestAccountTokens()
 
@@ -76,7 +76,7 @@ class CookieIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/35">#35</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100","config-default", "json", "html"])
     public void serverDeletesCookiesWhenRefreshingWithInvalidToken() throws Exception {
         def response = given()
             .cookie("refresh_token", "not_a_valid_refresh_token_at_all")
@@ -97,7 +97,7 @@ class CookieIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/121">#121</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100","config-default", "html"])
     public void unauthorizedHtmlRequestIsForwardedToLogin() throws Exception {
 
         // TODO: This test will probably have to change because we will be updating the spec.
@@ -115,7 +115,7 @@ class CookieIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/36">#38</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100","config-default", "json"])
     public void cookieExpirationMatchesTokenTtl() throws Exception {
         def account = new TestAccount()
         account.registerOnServer()
@@ -145,7 +145,7 @@ class CookieIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/232">#232</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100","config-default", "json", "html"])
     public void refreshTokenAsAccessTokenFails() throws Exception {
         def (String accessToken, String refreshToken) = createTestAccountTokens()
 

--- a/src/test/groovy/com/stormpath/tck/forgot/ChangePasswordIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/forgot/ChangePasswordIT.groovy
@@ -55,7 +55,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/166">#166</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void changeDoesNotHandlePut() throws Exception {
         put(ChangeRoute)
                 .then()
@@ -66,7 +66,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/166">#166</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void changeDoesNotHandleDelete() throws Exception {
         delete(ChangeRoute)
                 .then()
@@ -77,7 +77,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/239">#239</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void changeErrorsForInvalidSptokenJson() throws Exception {
 
         given()
@@ -94,7 +94,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/216">#216</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void changeErrorsForMissingSptokenJson() throws Exception {
 
         given()
@@ -110,7 +110,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/159">#159</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void changeErrorsForInvalidSptokenWhenPostingJson() throws Exception {
 
         given()
@@ -130,7 +130,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/147">#147</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void changeRedirectsToErrorUriForInvalidSptoken() throws Exception {
 
         given()
@@ -147,7 +147,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/151">#151</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void changeRediredctsToForgotUriForMissingSptoken() throws Exception {
 
         given()
@@ -163,7 +163,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/158">#158</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void changeRedirectsToErrorUriForInvalidSptokenWhenPosting() throws Exception {
 
         given()
@@ -182,7 +182,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/149">#149</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void changeRendersFormForValidSptoken() throws Exception {
 
         // TODO: work with CSRF?
@@ -219,7 +219,7 @@ class ChangePasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/155">#155</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void changeEndpointChangesAccountPasswordWhenPostingJson() throws Exception {
         // TODO: work with CSRF?
 

--- a/src/test/groovy/com/stormpath/tck/forgot/ForgotPasswordIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/forgot/ForgotPasswordIT.groovy
@@ -45,7 +45,7 @@ class ForgotPasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/165">#165</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void forgotDoesNotHandlePut() throws Exception {
         put(ForgotRoute)
             .then()
@@ -56,7 +56,7 @@ class ForgotPasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/165">#165</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void forgotDoesNotHandleDelete() throws Exception {
         delete(ForgotRoute)
             .then()
@@ -67,7 +67,7 @@ class ForgotPasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/215">#215</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void forgotDoesNotHandleJsonGet() throws Exception {
         given()
             .accept(ContentType.JSON)
@@ -81,7 +81,7 @@ class ForgotPasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/142">#142</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void forgotSucceedsWhenPostingValidEmailJson() throws Exception {
         given()
             .accept(ContentType.JSON)
@@ -97,7 +97,7 @@ class ForgotPasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/142">#142</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void forgotSucceedsWhenPostingInvalidEmailJson() throws Exception {
         given()
             .accept(ContentType.JSON)
@@ -113,7 +113,7 @@ class ForgotPasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/140">#140</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void forgotRendersForm() throws Exception {
 
         def response = given()
@@ -136,7 +136,7 @@ class ForgotPasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/141">#141</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void forgotRendersFormWithInvalidSptokenBanner() throws Exception {
 
         def response = given()
@@ -160,7 +160,7 @@ class ForgotPasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/143">#143</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void forgotRedirectsToNextUriWhenPostingValidEmail() throws Exception {
         given()
             .accept(ContentType.HTML)
@@ -177,7 +177,7 @@ class ForgotPasswordIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/143">#143</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void forgotRedirectsToNextUriWhenPostingInvalidEmail() throws Exception {
         given()
             .accept(ContentType.HTML)

--- a/src/test/groovy/com/stormpath/tck/login/FacebookSocialLoginIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/login/FacebookSocialLoginIT.groovy
@@ -96,7 +96,7 @@ class FacebookSocialLoginIT extends AbstractIT {
      * Attempts to login with the Facebook Access Token, and expects an account object back.
      * @throws Exception
      */
-    @Test(groups = ["v100", "json"])
+    @Test(groups = ["v100", "config-default", "json"])
     public void loginWithValidFacebookAccessTokenSucceeds() throws Exception {
         def loginJSON = ["providerData": [
                 "providerId": "facebook",
@@ -121,7 +121,7 @@ class FacebookSocialLoginIT extends AbstractIT {
      * Attempts to login with an invalid access token, and should fail. 
      * @throws Exception
      */
-    @Test(groups = ["v100", "json"])
+    @Test(groups = ["v100", "config-default", "json"])
     public void loginWithInvalidFacebookAccessTokenFails() throws Exception {
         def loginJSON = ["providerData": [
                 "providerId": "facebook",

--- a/src/test/groovy/com/stormpath/tck/login/LoginIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/login/LoginIT.groovy
@@ -80,7 +80,7 @@ class LoginIT extends AbstractIT {
     /** Only respond to GET and POST
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/85">#85</a>
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void loginDoesNotHandlePut() throws Exception {
         put(LoginRoute)
             .then()
@@ -90,7 +90,7 @@ class LoginIT extends AbstractIT {
     /** Only respond to GET and POST
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/85">#85</a>
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void loginDoesNotHandleDelete() throws Exception {
         delete(LoginRoute)
             .then()
@@ -102,7 +102,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/83">#83</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginServesJsonViewModel() throws Exception {
 
         given()
@@ -122,7 +122,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/89">#89</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginViewModelHasFields() throws Exception {
 
         given()
@@ -150,7 +150,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/93">#93</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginWithUsernameSucceeds() throws Exception {
 
         Map<String, Object>  credentials = new HashMap<>();
@@ -173,7 +173,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/93">#93</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginWithEmailSucceeds() throws Exception {
 
         given()
@@ -193,7 +193,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/95">#95</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginWithEmptyStringFails() throws Exception {
 
         Map<String, Object> badCredentials = new HashMap<>();
@@ -215,7 +215,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/95">#95</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginWithEmptyPasswordFails() throws Exception {
 
         Map<String, Object> badCredentials = new HashMap<>();
@@ -238,7 +238,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/100">#100</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginSucceedsForJson() throws Exception {
 
         given()
@@ -256,7 +256,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/101">#101</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginJsonDoesNotHaveLinkedResources() throws Exception {
 
         given()
@@ -274,7 +274,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/108">#108</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginAccountDatetimePropertiesAreIso8601() throws Exception {
 
         Response response =
@@ -304,7 +304,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/45">#110</a>
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/28">#28</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginErrorsWithBadCredentialsJson() throws Exception {
 
         Map<String, Object> badCredentials = new HashMap<>();
@@ -328,7 +328,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/33">#33</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void loginSetsCookiesJson() throws Exception {
 
         given()
@@ -346,7 +346,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/81">#81</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginServesHtmlForm() throws Exception {
 
         Response response =
@@ -375,7 +375,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/94">#94</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginHtmlRendersErrorWithoutUsernameAndPassword() throws Exception {
 
         // todo: work with CSRF
@@ -403,7 +403,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/33">#33</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginSetsCookiesHtml() throws Exception {
 
         // todo: work with CSRF
@@ -423,7 +423,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/92">#92</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginWithEmailSucceedsHtml() throws Exception {
 
         // todo: work with CSRF
@@ -442,7 +442,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/92">#92</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginWithUsernameSucceedsHtml() throws Exception {
 
         // todo: work with CSRF
@@ -461,7 +461,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/97">#97</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginRedirectsToNextUriOnSuccess() throws Exception {
 
         // todo: work with CSRF
@@ -481,7 +481,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/99">#99</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginRedirectsToNextQueryParameter() throws Exception {
 
         // todo: work with CSRF
@@ -502,7 +502,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/102">#102</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginRendersUnverifiedMessage() throws Exception {
 
         Response response =
@@ -527,7 +527,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/103">#103</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginRendersVerifiedMessage() throws Exception {
 
         Response response =
@@ -552,7 +552,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/104">#104</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginRendersCreatedMessage() throws Exception {
 
         Response response =
@@ -577,7 +577,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/105">#105</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginRendersForgotMessage() throws Exception {
 
         Response response =
@@ -602,7 +602,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/106">#106</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginRendersResetMessage() throws Exception {
 
         Response response =
@@ -627,7 +627,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/107">#107</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginDoesNotRenderWrongStatusParameter() throws Exception {
 
         Response response =
@@ -656,7 +656,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/44">#44</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginRendersErrorOnFailure() throws Exception {
 
         // todo: work with CSRF
@@ -684,7 +684,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/114">#114</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginFormShouldBeOrderedCorrectly() throws Exception {
 
         // todo: better CSRF handling
@@ -717,7 +717,7 @@ class LoginIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/177">#177</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void loginFormPreservesValuesOnPostback() throws Exception {
 
         // todo: work with CSRF

--- a/src/test/groovy/com/stormpath/tck/logout/LogoutIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/logout/LogoutIT.groovy
@@ -84,7 +84,7 @@ class LogoutIT extends AbstractIT {
     /** Only handle POST
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/54">#54</a>
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void logoutDoesNotHandleGet() throws Exception {
         get(LogoutRoute)
             .then()
@@ -94,7 +94,7 @@ class LogoutIT extends AbstractIT {
     /** Only handle POST
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/54">#54</a>
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void logoutDoesNotHandlePut() throws Exception {
         put(LogoutRoute)
             .then()
@@ -104,7 +104,7 @@ class LogoutIT extends AbstractIT {
     /** Only handle POST
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/54">#54</a>
      */
-    @Test(groups=["v100", "json", "html"])
+    @Test(groups=["v100", "config-default", "json", "html"])
     public void logoutDoesNotHandleDelete() throws Exception {
         delete(LogoutRoute)
             .then()
@@ -115,7 +115,7 @@ class LogoutIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/172">#172</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void logoutSucceedsOnUnauthenticatedJsonRequest() throws Exception {
 
         given()
@@ -130,7 +130,7 @@ class LogoutIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/174">#174</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void logoutDeletesCookiesJson() throws Exception {
         def sessionCookies = createSession()
 
@@ -151,7 +151,7 @@ class LogoutIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/171">#171</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void logoutReturns200OKOnSuccess() throws Exception {
         def sessionCookies = createSession()
 
@@ -168,7 +168,7 @@ class LogoutIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/175">#175</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void logoutRevokesTokensAfterSuccessJson() throws Exception {
         def sessionCookies = createSession()
 
@@ -185,7 +185,7 @@ class LogoutIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/173">#173</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void logoutRedirectsToNextUriOnUnauthenticatedRequest() throws Exception {
 
         given()
@@ -201,7 +201,7 @@ class LogoutIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/170">#170</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void logoutRedirectsToNextUriOnSuccess() throws Exception {
         def sessionCookies = createSession()
 
@@ -219,7 +219,7 @@ class LogoutIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/53">#53</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void logoutDeletesCookiesHtml() throws Exception {
         def sessionCookies = createSession()
 
@@ -240,7 +240,7 @@ class LogoutIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/169">#169</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void logoutRevokesTokensHtml() throws Exception {
         def sessionCookies = createSession()
 

--- a/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
@@ -60,7 +60,7 @@ class MeIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/37">#37</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void meFailsOnUnauthenticatedRequest() throws Exception {
         when()
             .get(MeRoute)
@@ -75,7 +75,7 @@ class MeIT extends AbstractIT {
      * @see https://github.com/stormpath/stormpath-framework-tck/issues/234
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void meWithCookieAuthReturnsJsonUser() throws Exception {
         given()
             .cookie("access_token", accessToken)
@@ -92,7 +92,7 @@ class MeIT extends AbstractIT {
      * @see https://github.com/stormpath/stormpath-framework-tck/issues/235
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void meWithBearerAuthReturnsJsonUser() throws Exception {
         given()
             .auth().oauth2(accessToken)
@@ -106,7 +106,7 @@ class MeIT extends AbstractIT {
      * Me should take Basic auth with an account's API keys as well.
      * @see https://github.com/stormpath/stormpath-framework-tck/issues/236
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void meWithBasicAuthReturnsJsonUser() throws Exception {
         Response apiKeysResource = given()
             .header("User-Agent", "stormpath-framework-tck")
@@ -136,7 +136,7 @@ class MeIT extends AbstractIT {
      * @see https://github.com/stormpath/stormpath-framework-tck/issues/234
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void meWithCookieAuthStripsLinkedResources() throws Exception {
         given()
             .cookie("access_token", accessToken)
@@ -152,7 +152,7 @@ class MeIT extends AbstractIT {
      * @see https://github.com/stormpath/stormpath-framework-tck/issues/235
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void meWithBearerAuthStripsLinkedResources() throws Exception {
         given()
             .auth().oauth2(accessToken)
@@ -168,7 +168,7 @@ class MeIT extends AbstractIT {
      * @see https://github.com/stormpath/stormpath-framework-tck/issues/234
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void meWithCookieAuthHasNoCacheHeaders() throws Exception {
         given()
             .cookie("access_token", accessToken)
@@ -187,7 +187,7 @@ class MeIT extends AbstractIT {
      * @see https://github.com/stormpath/stormpath-framework-tck/issues/235
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void meWithBearerAuthHasNoCacheHeaders() throws Exception {
         given()
             .auth().oauth2(accessToken)
@@ -203,7 +203,7 @@ class MeIT extends AbstractIT {
     /** We shouldn't be able to authenticate with a JWT that uses an algorithm of none.
      * @see https://github.com/stormpath/stormpath-framework-tck/issues/231
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void unsignedAccessTokensShouldFail() throws Exception {
         String unsignedAccessToken = changeJwtAlgorithmToNone(accessToken)
 

--- a/src/test/groovy/com/stormpath/tck/oauth2/Oauth2IT.groovy
+++ b/src/test/groovy/com/stormpath/tck/oauth2/Oauth2IT.groovy
@@ -43,7 +43,7 @@ class Oauth2IT extends AbstractIT {
     /** Unsupported grant type returns error
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/6">#6</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthErrorsOnUnsupportedGrantTypes() throws Exception {
 
         given()
@@ -59,7 +59,7 @@ class Oauth2IT extends AbstractIT {
     /** Missing grant type returns error
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/7">#7</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthErrorsOnMissingGrantType() throws Exception {
         given()
             .param("grant_type", "")
@@ -74,7 +74,7 @@ class Oauth2IT extends AbstractIT {
     /** POST must include form parameters
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/15">#15</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthErrorsOnInvalidRequestBody() throws Exception {
         given()
             .body("""hello"" : ""world""")
@@ -89,7 +89,7 @@ class Oauth2IT extends AbstractIT {
     /** GET should return 405
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/16">#16</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthDoesntSupportGet() throws Exception {
         get(OauthRoute)
             .then()
@@ -99,7 +99,7 @@ class Oauth2IT extends AbstractIT {
     /** Password grant flow with username/password
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/11">#11</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthPasswordGrantWithUsernameSucceeds() throws Exception {
 
         String accessToken =
@@ -120,7 +120,7 @@ class Oauth2IT extends AbstractIT {
     /** Password grant flow with email/password
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/18">#18</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthPasswordGrantWithEmailSucceeds() throws Exception {
 
         String accessToken =
@@ -141,7 +141,7 @@ class Oauth2IT extends AbstractIT {
     /** Refresh grant flow
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/205">#205</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthRefreshGrantWorksWithValidToken() throws Exception {
         Response passwordGrantResponse =
             given()
@@ -176,7 +176,7 @@ class Oauth2IT extends AbstractIT {
     /** Refresh grant flow should fail without valid refresh token
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/205">#205</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthRefreshGrantFailsWithInvalidRefreshToken() throws Exception {
         String refreshToken = "GARBAGE"
 
@@ -197,7 +197,7 @@ class Oauth2IT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/12">#12</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthErrorsAreTransformedProperly() throws Exception {
 
         given()
@@ -217,7 +217,7 @@ class Oauth2IT extends AbstractIT {
     /** We should be able to use the client_credentials grant type to get an access token
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/8">#8</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthClientCredentialsGrantSucceeds() throws Exception {
         TestAccount testAccount = new TestAccount()
         testAccount.registerOnServer()
@@ -262,7 +262,7 @@ class Oauth2IT extends AbstractIT {
     /** We shouldn't be able to use client credentials to get an access token without a API secret
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/8">#8</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void oauthClientCredentialsGrantFailsWithoutAPISecret() throws Exception {
         TestAccount testAccount = new TestAccount()
         testAccount.registerOnServer()

--- a/src/test/groovy/com/stormpath/tck/register/RegisterIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/register/RegisterIT.groovy
@@ -75,7 +75,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/179">#179</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void registerServesJsonViewModel() throws Exception {
 
         given()
@@ -95,7 +95,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/189">#189</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void registerErrorsOnEmptyPostJson() throws Exception {
 
         given()
@@ -112,7 +112,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/189">#189</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void registerErrorsOnMissingPostBodyJson() throws Exception {
 
         def jsonMap = [email: testAccount.email,
@@ -133,7 +133,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/189">#189</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void registerErrorsOnMissingField() throws Exception {
 
         def jsonMap = [email: testAccount.email,
@@ -156,7 +156,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/195">#195</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void registerErrorsForUndefinedFields() throws Exception {
 
         def jsonMap = [email: testAccount.email,
@@ -181,7 +181,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/195">#195</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void registerErrorsForUndefinedCustomFields() throws Exception {
 
         def jsonMap = [email: testAccount.email,
@@ -207,7 +207,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/201">#201</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void registerErrorsOnServerError() throws Exception {
 
         def jsonMap = [email: "foo@bar",
@@ -231,7 +231,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/202">#202</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void registerReturnsSanitizedJsonAccount() throws Exception {
 
         def testAccount = new TestAccount()
@@ -256,7 +256,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/180">#180</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void registerServesHtmlForm() throws Exception {
 
         Response response =
@@ -280,7 +280,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/181">#181</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void registerFormShouldBeOrdered() throws Exception {
 
         // Todo: CSRF support
@@ -322,7 +322,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/188">#188</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void registerErrorsWithEmptyPostBody() throws Exception {
 
         // Todo: CSRF support
@@ -350,7 +350,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/188">#188</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void registerErrorsWithMissingPasswordHtml() throws Exception {
 
         // todo: work with CSRF
@@ -380,7 +380,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/188">#188</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void registerErrorsWithMissingFormFieldsHtml() throws Exception {
 
         // todo: work with CSRF
@@ -412,7 +412,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/194">#194</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void registerErrorsForUndefinedFieldsHtml() throws Exception {
 
         // todo: work with CSRF
@@ -445,7 +445,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/200">#200</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void registerErrorsOnServerErrorHtml() throws Exception {
 
         Response response =
@@ -476,7 +476,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/203">#203</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void registerRedirectToLoginOnSuccess() throws Exception {
 
         given()
@@ -501,7 +501,7 @@ class RegisterIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/219">#219</a>
      * @throws Exception
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void registerFormPreservesValuesOnPostback() throws Exception {
 
         // todo: work with CSRF

--- a/src/test/groovy/com/stormpath/tck/requests/RequestsIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/requests/RequestsIT.groovy
@@ -31,7 +31,7 @@ class RequestsIT extends AbstractIT {
      * Null or empty Accept header is treated as * / *
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/72">#72</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void emptyAcceptHeaderShouldGetJson() {
 
         given()
@@ -48,7 +48,7 @@ class RequestsIT extends AbstractIT {
      * Null or empty Accept header is treated as * / *
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/72">#72</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void missingAcceptHeaderShouldGetJson() {
 
         given()
@@ -64,7 +64,7 @@ class RequestsIT extends AbstractIT {
      * Accept: * / * uses first value in web.produces as Content-Type
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/73">#73</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void anyAcceptHeaderShouldGetJson() {
 
         given()
@@ -81,7 +81,7 @@ class RequestsIT extends AbstractIT {
      * Specifying valid Accept Content-Type returns that Content-Type
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/75">#75</a>
      */
-    @Test(groups=["v100", "json"])
+    @Test(groups=["v100", "config-default", "json"])
     public void jsonAcceptHeaderShouldReturnJson() {
 
         given()
@@ -97,7 +97,7 @@ class RequestsIT extends AbstractIT {
      * Specifying valid Accept Content-Type returns that Content-Type
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/75">#75</a>
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void htmlAcceptHeaderShouldReturnHtml() {
 
         given()
@@ -113,7 +113,7 @@ class RequestsIT extends AbstractIT {
      * Unknown Accept header is not handled
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/76">#76</a>
      */
-    @Test(groups=["v100", "html"])
+    @Test(groups=["v100", "config-default", "html"])
     public void unknownAcceptHeaderIsNotHandled() {
 
         given()

--- a/src/test/suite-default.xml
+++ b/src/test/suite-default.xml
@@ -1,0 +1,27 @@
+<!DOCTYPE suite SYSTEM "http://beust.com/testng/testng-1.0.dtd" >
+<suite name="Spec v1.0 - Default Configuration">
+    <test name="html" preserve-order="true">
+        <method-selectors>
+            <method-selector>
+                <script language="beanshell"><![CDATA[
+                    groups.containsKey("v100") && groups.containsKey("html")
+                ]]></script>
+            </method-selector>
+        </method-selectors>
+        <packages>
+            <package name="com.stormpath.tck.*" />
+        </packages>
+    </test>
+    <test name="json" preserve-order="true">
+        <method-selectors>
+            <method-selector>
+                <script language="beanshell"><![CDATA[
+                    groups.containsKey("v100") && groups.containsKey("json")
+                ]]></script>
+            </method-selector>
+        </method-selectors>
+        <packages>
+            <package name="com.stormpath.tck.*" />
+        </packages>
+    </test>
+</suite>

--- a/src/test/suite-default.xml
+++ b/src/test/suite-default.xml
@@ -4,7 +4,9 @@
         <method-selectors>
             <method-selector>
                 <script language="beanshell"><![CDATA[
-                    groups.containsKey("v100") && groups.containsKey("html")
+                    groups.containsKey("v100") &&
+                    groups.containsKey("config-default") &&
+                    groups.containsKey("html")
                 ]]></script>
             </method-selector>
         </method-selectors>
@@ -16,7 +18,9 @@
         <method-selectors>
             <method-selector>
                 <script language="beanshell"><![CDATA[
-                    groups.containsKey("v100") && groups.containsKey("json")
+                    groups.containsKey("v100") &&
+                    groups.containsKey("config-default") &&
+                    groups.containsKey("json")
                 ]]></script>
             </method-selector>
         </method-selectors>


### PR DESCRIPTION
Looking for any feedback on this: @edjiang @dogeared @mrioan 

I spec'ed out a way to support multiple test "suites" in the TCK, for when we need to test different `stormpath.yaml` configurations.

Every test is tagged with groups that indicate the following:
- The framework-spec version - `v100`, `v101`
- The content type - `html`, `json` (or both)
- A configuration name - `config-default` for now, maybe `config-idsite`, `config-multitenant` and others in the future

I created a surefire test file called `suite-default.xml`. It wraps up a cross-section of the tests: all v1.0.0 default configuration HTML tests, and v1.0.0 default configuration JSON tests.

With all this done, it's possible to run this on the command line:

```
mvn clean verify -Dsuite=default -Dtag=json
```

Any feedback is appreciated!
