### PR TITLE
Test for JSON and HTML 404 and 401 errors

### DIFF
--- a/src/test/groovy/com/stormpath/tck/errors/ErrorsIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/errors/ErrorsIT.groovy
@@ -14,63 +14,31 @@
  * limitations under the License.
  */
 
-package com.stormpath.tck.errors;
+package com.stormpath.tck.errors
 
-import com.jayway.restassured.http.ContentType;
-import com.stormpath.tck.AbstractIT;
-import org.testng.annotations.Test;
+import com.jayway.restassured.http.ContentType
+import com.stormpath.tck.AbstractIT
+import org.testng.annotations.Test
 
 import static com.jayway.restassured.RestAssured.given
-import static com.stormpath.tck.util.FrameworkConstants.MeRoute;
+import static com.stormpath.tck.util.FrameworkConstants.MeRoute
 import static com.stormpath.tck.util.FrameworkConstants.MissingRoute
-import static org.hamcrest.CoreMatchers.containsString;
 
 @Test
 class ErrorsIT extends AbstractIT {
 
     /**
-     * A missing endpoint should return HTML when Accept header is text/html
+     * A missing endpoint should return a 404
      * @see <a href="https://github.com/stormpath/stormpath-sdk-java/issues/706">#706</a>
      */
     @Test(groups=["v100", "html"])
-    public void missingEndpointShouldReturn404AsHTML() {
+    public void missingEndpointShouldReturn404() {
         given()
             .header("Accept", ContentType.HTML)
         .when()
             .get(MissingRoute)
         .then()
             .statusCode(404)
-            .header("Content-Type", containsString(ContentType.HTML.toString()))
-    }
-
-    /**
-     * A missing endpoint should return JSON when Accept header is application/json
-     * @see <a href="https://github.com/stormpath/stormpath-sdk-java/issues/706">#706</a>
-     */
-    @Test(groups=["v100", "json"])
-    public void missingEndpointShouldReturn404AsJSON() {
-        given()
-            .header("Accept", ContentType.JSON)
-        .when()
-            .get(MissingRoute)
-        .then()
-            .statusCode(404)
-            .contentType(ContentType.JSON)
-    }
-
-    /**
-     * A restricted endpoint should return a redirect to login when Accept header is text/html
-     * @see <a href="https://github.com/stormpath/stormpath-sdk-java/issues/706">#706</a>
-     */
-    @Test(groups=["v100", "html"])
-    public void restrictedEndpointShouldReturn302ToLogin() {
-        given()
-            .header("Accept", ContentType.HTML)
-        .when()
-            .get(MeRoute)
-        .then()
-            .statusCode(302)
-            .header("Location", "http://localhost:8080/login?next=%2Fme")
     }
 
     /**
@@ -78,7 +46,7 @@ class ErrorsIT extends AbstractIT {
      * @see <a href="https://github.com/stormpath/stormpath-sdk-java/issues/706">#706</a>
      */
     @Test(groups=["v100", "json"])
-    public void restrictedEndpointShouldReturn401AsJSON() {
+    public void restrictedEndpointShouldReturn401AndWWWAuthenticateHeader() {
         given()
             .header("Accept", ContentType.JSON)
         .when()

--- a/src/test/groovy/com/stormpath/tck/errors/ErrorsIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/errors/ErrorsIT.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stormpath.tck.errors;
+
+import com.jayway.restassured.http.ContentType;
+import com.stormpath.tck.AbstractIT;
+import org.testng.annotations.Test;
+
+import static com.jayway.restassured.RestAssured.given
+import static com.stormpath.tck.util.FrameworkConstants.MeRoute;
+import static com.stormpath.tck.util.FrameworkConstants.MissingRoute
+import static org.hamcrest.CoreMatchers.containsString;
+
+@Test
+class ErrorsIT extends AbstractIT {
+
+    /**
+     * A missing endpoint should return HTML when Accept header is text/html
+     * @see <a href="https://github.com/stormpath/stormpath-sdk-java/issues/706">#706</a>
+     */
+    @Test(groups=["v100", "html"])
+    public void missingEndpointShouldReturn404AsHTML() {
+        given()
+            .header("Accept", ContentType.HTML)
+        .when()
+            .get(MissingRoute)
+        .then()
+            .statusCode(404)
+            .header("Content-Type", containsString(ContentType.HTML.toString()))
+    }
+
+    /**
+     * A missing endpoint should return JSON when Accept header is application/json
+     * @see <a href="https://github.com/stormpath/stormpath-sdk-java/issues/706">#706</a>
+     */
+    @Test(groups=["v100", "json"])
+    public void missingEndpointShouldReturn404AsJSON() {
+        given()
+            .header("Accept", ContentType.JSON)
+        .when()
+            .get(MissingRoute)
+        .then()
+            .statusCode(404)
+            .contentType(ContentType.JSON)
+    }
+
+    /**
+     * A restricted endpoint should return a redirect to login when Accept header is text/html
+     * @see <a href="https://github.com/stormpath/stormpath-sdk-java/issues/706">#706</a>
+     */
+    @Test(groups=["v100", "html"])
+    public void restrictedEndpointShouldReturn302ToLogin() {
+        given()
+            .header("Accept", ContentType.HTML)
+        .when()
+            .get(MeRoute)
+        .then()
+            .statusCode(302)
+            .header("Location", "http://localhost:8080/login?next=%2Fme")
+    }
+
+    /**
+     * A restricted endpoint should return JSON when Accept header is application/json
+     * @see <a href="https://github.com/stormpath/stormpath-sdk-java/issues/706">#706</a>
+     */
+    @Test(groups=["v100", "json"])
+    public void restrictedEndpointShouldReturn401AsJSON() {
+        given()
+            .header("Accept", ContentType.JSON)
+        .when()
+            .get(MeRoute)
+        .then()
+            .statusCode(401)
+            // 401 with Accept JSON header does not return JSON
+            .header("WWW-Authenticate", "Bearer realm=\"My Application\"")
+    }
+}

--- a/src/test/groovy/com/stormpath/tck/util/FrameworkConstants.groovy
+++ b/src/test/groovy/com/stormpath/tck/util/FrameworkConstants.groovy
@@ -24,4 +24,5 @@ class FrameworkConstants {
     static String VerifyRoute = "/verify"
     static String ForgotRoute = "/forgot"
     static String ChangeRoute = "/change"
+    static String MissingRoute = "/missing" // should 404
 }


### PR DESCRIPTION
Either this test needs to be fixed, or the various Java examples do, as there's failures with every example:

examples/servlet
- missingEndpointShouldReturn404AsJSON fails

examples/spring-boot-default
- missingEndpointShouldReturn404AsJSON fails
- restrictedEndpointShouldReturn302ToLogin fails (Exception processing template "stormpathJsonView")
- restrictedEndpointShouldReturn401AsJSON fails ("WWW-Authenticate" header is missing)

examples/spring-boot-webmvc
- restrictedEndpointShouldReturn302ToLogin fails (Error resolving template "stormpathJsonView")
- restrictedEndpointShouldReturn401AsJSON fails ("WWW-Authenticate" header is missing)

examples/spring-security-spring-boot-webmvc
- missingEndpointShouldReturn404AsJSON fails
- restrictedEndpointShouldReturn302ToLogin fails (Exception processing template "stormpathJsonView")
- restrictedEndpointShouldReturn401AsJSON fails ("WWW-Authenticate" header is missing)

examples/spring-security-webmvc
- restrictedEndpointShouldReturn302ToLogin fails (Expected status code <302> doesn't match actual status code <401>)
- restrictedEndpointShouldReturn401AsJSON fails ("WWW-Authenticate" header is missing)

examples/spring-webmvc
- restrictedEndpointShouldReturn302ToLogin fails (Expected status code <302> doesn't match actual status code <401>)
- restrictedEndpointShouldReturn401AsJSON fails ("WWW-Authenticate" header is missing)
