### PR TITLE
Check for status code on MeIT

### DIFF
--- a/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
+++ b/src/test/groovy/com/stormpath/tck/me/MeIT.groovy
@@ -90,6 +90,7 @@ class MeIT extends AbstractIT {
             .when()
                 .get(MeRoute)
             .then()
+                .statusCode(200)
                 .spec(AccountResponseSpec.matchesAccount(account))
         }
     }
@@ -108,6 +109,7 @@ class MeIT extends AbstractIT {
         .when()
             .get(MeRoute)
         .then()
+            .statusCode(200)
             .spec(AccountResponseSpec.matchesAccount(account))
     }
 
@@ -137,6 +139,7 @@ class MeIT extends AbstractIT {
         .when()
             .get(MeRoute)
         .then()
+            .statusCode(200)
             .spec(AccountResponseSpec.matchesAccount(account))
     }
 


### PR DESCRIPTION
I had a 500 error but the TCK only reported that the response doesn't have an account href property. If it had a check for the status code before that I would have managed to do a quicker fix on my side.

Hope this helps others :)
