### PR TITLE
Cache header should contain the string no-store instead of the collection ["no-store"]

### DIFF
--- a/src/test/groovy/com/stormpath/tck/oauth2/Oauth2IT.groovy
+++ b/src/test/groovy/com/stormpath/tck/oauth2/Oauth2IT.groovy
@@ -29,7 +29,6 @@ import org.testng.annotations.Test
 import static com.jayway.restassured.RestAssured.get
 import static com.jayway.restassured.RestAssured.given
 import static com.stormpath.tck.util.FrameworkConstants.OauthRoute
-import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.equalToIgnoringCase
 import static org.hamcrest.Matchers.is
@@ -305,7 +304,7 @@ class Oauth2IT extends AbstractIT {
             .body("token_type", equalToIgnoringCase("Bearer"))
             .body("expires_in", is(3600))
             .body("refresh_token", nullValue())
-            .header("Cache-Control", contains("no-store"))
+            .header("Cache-Control", containsString("no-store"))
             .header("Pragma", is("no-cache"))
     }
 


### PR DESCRIPTION
Fixes stormpath/stormpath-sdk-java#773
