### PR TITLE
Enable client credentials IT

### DIFF
--- a/src/main/groovy/com/stormpath/tck/oauth2/Oauth2IT.groovy
+++ b/src/main/groovy/com/stormpath/tck/oauth2/Oauth2IT.groovy
@@ -20,6 +20,7 @@ import com.jayway.restassured.http.ContentType
 import com.jayway.restassured.response.Response
 import com.stormpath.tck.AbstractIT
 import com.stormpath.tck.responseSpecs.JsonResponseSpec
+import com.stormpath.tck.util.EnvUtils
 import com.stormpath.tck.util.JwtUtils
 import org.testng.annotations.Test
 
@@ -266,35 +267,15 @@ class Oauth2IT extends AbstractIT {
     /**
      * We should be able to use the client_credentials grant type to get an access token
      * @see <a href="https://github.com/stormpath/stormpath-framework-tck/issues/8">#8</a>
-     *
-     * TODO - disabling because of Stormpath specific interactions
      */
-    @Test(groups=["v100", "json"], enabled = false)
+    @Test(groups=["v100", "json"])
     void oauthClientCredentialsGrantSucceeds() throws Exception {
-        // Get API keys so we can use it for client credentials
-
-        def account = createTestAccount()
-        Response apiKeysResource = given()
-            .header("User-Agent", "stormpath-framework-tck")
-            .header("Authorization", RestUtils.getBasicAuthorizationHeaderValue())
-            .header("Content-Type", "application/json")
-            .port(443)
-        .when()
-            .post(account.href + "/apiKeys")
-        .then()
-            .statusCode(201)
-        .extract()
-            .response()
-
-        String apiKeyId = apiKeysResource.body().jsonPath().getString("id")
-        String apiKeySecret = apiKeysResource.body().jsonPath().getString("secret")
 
         // Attempt to get tokens
-
         given()
             .param("grant_type", "client_credentials")
             .auth()
-                .preemptive().basic(apiKeyId, apiKeySecret)
+                .preemptive().basic(EnvUtils.clientCredentialsId, EnvUtils.clientCredentialsSecret)
             .contentType(ContentType.URLENC)
         .when()
             .post(OauthRoute)

--- a/src/main/groovy/com/stormpath/tck/util/EnvUtils.groovy
+++ b/src/main/groovy/com/stormpath/tck/util/EnvUtils.groovy
@@ -27,18 +27,23 @@ class EnvUtils {
     public static final String facebookClientSecret
     public static final String jwtSigningKeysUrl
 
+    public static final String clientCredentialsId
+    public static final String clientCredentialsSecret
+
     static {
         jwtSigningKeysUrl = getVal("STORMPATH_TCK_VALIDATE_JWT_URL")
         jwtSigningKey = getVal("JWT_SIGNING_KEY")
         facebookClientId = getVal("FACEBOOK_CLIENT_ID")
         facebookClientSecret = getVal("FACEBOOK_CLIENT_SECRET")
+        clientCredentialsId = getVal("STORMPATH_CLIENT_CREDENTIALS_ID")
+        clientCredentialsSecret = getVal("STORMPATH_CLIENT_CREDENTIALS_SECRET")
 
         if (jwtSigningKeysUrl == null && jwtSigningKey == null) {
             fail("One of JWT_SIGNING_KEY or STORMPATH_TCK_VALIDATE_JWT_URL environment variables is required")
         }
 
-        if (jwtSigningKey == null || facebookClientId == null || facebookClientSecret == null) {
-            fail("FACEBOOK_CLIENT_ID and FACEBOOK_CLIENT_SECRET environment variables are required")
+        if (jwtSigningKey == null || facebookClientId == null || facebookClientSecret == null || clientCredentialsId == null || clientCredentialsSecret == null) {
+            fail("STORMPATH_CLIENT_CREDENTIALS_ID, STORMPATH_CLIENT_CREDENTIALS_SECRET, FACEBOOK_CLIENT_ID and FACEBOOK_CLIENT_SECRET environment variables are required")
         }
     }
 


### PR DESCRIPTION
This test require an existing user with and ID & secret set as env vars: STORMPATH_CLIENT_CREDENTIALS_ID, STORMPATH_CLIENT_CREDENTIALS_SECRET