### PR TITLE
Added test for token from client_credentials grant_type.

### DIFF
--- a/src/main/groovy/com/stormpath/tck/me/MeIT.groovy
+++ b/src/main/groovy/com/stormpath/tck/me/MeIT.groovy
@@ -110,6 +110,19 @@ class MeIT extends AbstractIT {
         }
     }
 
+    @Test(groups=["v100", "json"])
+    void meWithCookieAuthFromClientCredentialsReturnsJsonUser() throws Exception {
+        ["text/html", "application/json", "*/*", ""].each { contentType ->
+            given()
+                .header("Accept", contentType)
+                .cookie("access_token", accessTokenFromClientCredentials)
+            .when()
+                .get(MeRoute)
+            .then()
+                .spec(AccountResponseSpec.matchesAccount(account))
+        }
+    }
+
     /**
      * We should be returning a user, and it should always be JSON.
      * @see https://github.com/stormpath/stormpath-framework-tck/issues/61


### PR DESCRIPTION
NOTE: The test currently fails, highlighting an issue in the Java SDK where access tokens returned from grant_type=client_credentials do not work as bearer tokens.